### PR TITLE
Fix acme fitness store accelerator

### DIFF
--- a/accelerator.yaml
+++ b/accelerator.yaml
@@ -13,4 +13,5 @@ accelerator:
 
 engine:
   merge:
-    - include: [ "apps/**", "azure-spring-apps-enterprise/media/**", "*.md", "LICENSE", ".gitignore"]
+    - include: [ "apps/**", "azure-spring-apps-enterprise/**", "*.md", "LICENSE", ".gitignore" ]
+      exclude: [ "azure-spring-apps-enterprise/media/**" ]


### PR DESCRIPTION
I have modified the `include` for media folder due to png and jpg files are too heavy when trying to download the accelerator fails for timeout.

In the past we have solved this problem using a generic 1 kb image. Here I just excluded the whole folder.